### PR TITLE
 Adding support for MinGW environment

### DIFF
--- a/slack-theme
+++ b/slack-theme
@@ -97,6 +97,9 @@ then
 elif [ "$(uname)" == "Darwin" ] # Mac OS
 then
     INTEROP_FILE="/Applications/Slack.app/Contents/Resources/app.asar.unpacked/src/static/ssb-interop.js"
+elif [[ "$(uname)" == *"MINGW"* ]] # MinGW
+then
+    INTEROP_FILE="$SLACK_PATH/resources/app.asar.unpacked/src/static/ssb-interop.js"
 fi
 
 if [ -z "$SLACK_THEME_SHELL_PROFILE" ]


### PR DESCRIPTION
1. Added check for `"MINGW"` as one of the OSes when setting the path of `INTEROP_FILE`.